### PR TITLE
style: fixed cards padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,9 @@
   border-radius: 0.8em;
   color: #fff;
 }
+.path-local-helpdesk .top-tikets-infos .ticket-card .card-body {
+  padding: 1.25rem 1.5rem;
+}
 .path-local-helpdesk .top-tikets-infos .ticket-card:before {
   content: "◦";
   position: absolute;
@@ -109,13 +112,13 @@
 .path-local-helpdesk .top-tikets-infos .ticket-card .top-ticket-title {
   font-size: 19px;
   line-height: 1.6;
-  margin-bottom: 3px;
+  margin: 0 0 3px;
   color: #fff;
 }
 .path-local-helpdesk .top-tikets-infos .ticket-card h3 {
   color: #fff;
   font-size: 30px;
-  margin-left: 7px;
+  margin: 0;
 }
 .path-local-helpdesk .top-tikets-infos .ticket-card-1 {
   background-color: #2196f3;

--- a/styles.scss
+++ b/styles.scss
@@ -102,6 +102,9 @@
             transition: all .3s ease;
             border-radius: 0.8em;
             color: #fff;
+            .card-body {
+                padding: 1.25rem 1.5rem;
+            }
             &:before {
                 content: "◦";
                 position: absolute;
@@ -115,13 +118,13 @@
             .top-ticket-title {
                 font-size: 19px;
                 line-height: 1.6;
-                margin-bottom: 3px;
+                margin: 0 0 3px;
                 color: #fff;
             }
             h3 {
                 color: #fff;
                 font-size: 30px;
-                margin-left: 7px;
+                margin: 0;
             }
         }
         .ticket-card-1 {


### PR DESCRIPTION
card-body padding from Bootstrap does not apply when the element is not
inside a .card container. Add explicit padding to .ticket-card .card-body
and normalize title/count margins.

<img width="700" height="141" alt="Screenshot 2026-07-02 at 13 13 04" src="https://github.com/user-attachments/assets/b9daae84-eae8-483e-93d3-785de45e75c8" />
<img width="575" height="111" alt="Screenshot 2026-07-02 at 13 12 57" src="https://github.com/user-attachments/assets/9a5593d9-a291-4931-80d3-4ad1ef5065f4" />
